### PR TITLE
Fix missing developer portal slug after Libra2 rename

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -133,7 +133,7 @@ export default defineConfig({
                   {
                     base: "rest-api",
                     label: "REST API Reference",
-                    schema: "./public/aptos-spec.json",
+                    schema: "./public/libra2-spec.json",
                     sidebarMethodBadges: true,
                   },
                 ],

--- a/astro.sidebar.ts
+++ b/astro.sidebar.ts
@@ -103,16 +103,16 @@ export const sidebar = [
   // --- SDKS & TOOLS Tab (Focus: Tools & APIs for Integration) ---
   group("sdksAndTools", {
     items: [
-      // Aptos APIs
+      // Libra2 APIs
       {
-        label: "Aptos APIs",
+        label: "Libra2 APIs",
         collapsed: true,
         items: [
           "build/apis",
           "build/apis/fullnode-rest-api",
           "build/apis/faucet-api",
           "build/apis/data-providers",
-          "build/apis/aptos-labs-developer-portal",
+          "build/apis/libra2-core-developer-portal",
         ],
       },
 

--- a/public/libra2-spec.json
+++ b/public/libra2-spec.json
@@ -55,9 +55,7 @@
   "paths": {
     "/accounts/{address}": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account",
         "description": "Return the authentication key and the sequence number for an account\naddress. Optionally, a ledger version can be specified. If the ledger\nversion is not specified in the request, the latest ledger version is used.",
         "parameters": [
@@ -646,9 +644,7 @@
     },
     "/accounts/{address}/resources": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account resources",
         "description": "Retrieves all account resources for a given account and a specific ledger version.  If the\nledger version is not specified in the request, the latest ledger version is used.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -1263,9 +1259,7 @@
     },
     "/accounts/{address}/balance/{asset_type}": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account resources",
         "description": "Retrieves all account resources for a given account and a specific ledger version.  If the\nledger version is not specified in the request, the latest ledger version is used.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -1865,9 +1859,7 @@
     },
     "/accounts/{address}/modules": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account modules",
         "description": "Retrieves all account modules' bytecode for a given account at a specific ledger version.\nIf the ledger version is not specified in the request, the latest ledger version is used.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -2482,9 +2474,7 @@
     },
     "/spec": {
       "get": {
-        "tags": [
-          "General"
-        ],
+        "tags": ["General"],
         "summary": "Show OpenAPI explorer",
         "description": "Provides a UI that you can use to explore the API. You can also\nretrieve the API directly at `/spec.yaml` and `/spec.json`.",
         "responses": {
@@ -2504,9 +2494,7 @@
     },
     "/info": {
       "get": {
-        "tags": [
-          "General"
-        ],
+        "tags": ["General"],
         "summary": "Show some basic info of the node.",
         "responses": {
           "200": {
@@ -2526,9 +2514,7 @@
     },
     "/-/healthy": {
       "get": {
-        "tags": [
-          "General"
-        ],
+        "tags": ["General"],
         "summary": "Check basic node health",
         "description": "By default this endpoint just checks that it can get the latest ledger\ninfo and then returns 200.\n\nIf the duration_secs param is provided, this endpoint will return a\n200 if the following condition is true:\n\n`server_latest_ledger_info_timestamp >= server_current_time_timestamp - duration_secs`",
         "parameters": [
@@ -2803,9 +2789,7 @@
     },
     "/blocks/by_height/{block_height}": {
       "get": {
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "summary": "Get blocks by height",
         "description": "This endpoint allows you to get the transactions in a block\nand the corresponding block information.\n\nTransactions are limited by max default transactions size.  If not all transactions\nare present, the user will need to query for the rest of the transactions via the\nget transactions API.\n\nIf the block is pruned, it will return a 410",
         "parameters": [
@@ -3395,9 +3379,7 @@
     },
     "/blocks/by_version/{version}": {
       "get": {
-        "tags": [
-          "Blocks"
-        ],
+        "tags": ["Blocks"],
         "summary": "Get blocks by version",
         "description": "This endpoint allows you to get the transactions in a block\nand the corresponding block information given a version in the block.\n\nTransactions are limited by max default transactions size.  If not all transactions\nare present, the user will need to query for the rest of the transactions via the\nget transactions API.\n\nIf the block has been pruned, it will return a 410",
         "parameters": [
@@ -3987,9 +3969,7 @@
     },
     "/accounts/{address}/events/{creation_number}": {
       "get": {
-        "tags": [
-          "Events"
-        ],
+        "tags": ["Events"],
         "summary": "Get events by creation number",
         "description": "Event types are globally identifiable by an account `address` and\nmonotonically increasing `creation_number`, one per event type emitted\nto the given account. This API returns events corresponding to that\nthat event type.",
         "parameters": [
@@ -4604,9 +4584,7 @@
     },
     "/accounts/{address}/events/{event_handle}/{field_name}": {
       "get": {
-        "tags": [
-          "Events"
-        ],
+        "tags": ["Events"],
         "summary": "Get events by event handle",
         "description": "This API uses the given account `address`, `eventHandle`, and `fieldName`\nto build a key that can globally identify an event types. It then uses this\nkey to return events emitted to the given account matching that event type.",
         "parameters": [
@@ -5232,9 +5210,7 @@
     },
     "/": {
       "get": {
-        "tags": [
-          "General"
-        ],
+        "tags": ["General"],
         "summary": "Get ledger info",
         "description": "Get the latest ledger information, including data such as chain ID,\nrole type, ledger versions, epoch, etc.",
         "responses": {
@@ -5647,9 +5623,7 @@
     },
     "/accounts/{address}/resource/{resource_type}": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account resource",
         "description": "Retrieves an individual resource from a given account and at a specific ledger version. If the\nledger version is not specified in the request, the latest ledger version is used.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -6249,9 +6223,7 @@
     },
     "/accounts/{address}/module/{module_name}": {
       "get": {
-        "tags": [
-          "Accounts"
-        ],
+        "tags": ["Accounts"],
         "summary": "Get account module",
         "description": "Retrieves an individual module from a given account and at a specific ledger version. If the\nledger version is not specified in the request, the latest ledger version is used.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -6851,9 +6823,7 @@
     },
     "/tables/{table_handle}/item": {
       "post": {
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "summary": "Get table item",
         "description": "Get a table item at a specific ledger version from the table identified by {table_handle}\nin the path and the \"key\" (TableItemRequest) provided in the request body.\n\nThis is a POST endpoint because the \"key\" for requesting a specific\ntable item (TableItemRequest) could be quite complex, as each of its\nfields could themselves be composed of other structs. This makes it\nimpractical to express using query params, meaning GET isn't an option.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -7452,9 +7422,7 @@
     },
     "/tables/{table_handle}/raw_item": {
       "post": {
-        "tags": [
-          "Tables"
-        ],
+        "tags": ["Tables"],
         "summary": "Get raw table item",
         "description": "Get a table item at a specific ledger version from the table identified by {table_handle}\nin the path and the \"key\" (RawTableItemRequest) provided in the request body.\n\nThe `get_raw_table_item` requires only a serialized key comparing to the full move type information\ncomparing to the `get_table_item` api, and can only return the query in the bcs format.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -8053,9 +8021,7 @@
     },
     "/transactions": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Get transactions",
         "description": "Retrieve on-chain committed transactions. The page size and start ledger version\ncan be provided to get a specific sequence of transactions.\n\nIf the version has been pruned, then a 410 will be returned.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
@@ -8646,9 +8612,7 @@
         "operationId": "get_transactions"
       },
       "post": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Submit transaction",
         "description": "This endpoint accepts transaction submissions in two formats.\n\nTo submit a transaction as JSON, you must submit a SubmitTransactionRequest.\nTo build this request, do the following:\n\n1. Encode the transaction as BCS. If you are using a language that has\nnative BCS support, make sure of that library. If not, you may take\nadvantage of /transactions/encode_submission. When using this\nendpoint, make sure you trust the node you're talking to, as it is\npossible they could manipulate your request.\n2. Sign the encoded transaction and use it to create a TransactionSignature.\n3. Submit the request. Make sure to use the \"application/json\" Content-Type.\n\nTo submit a transaction as BCS, you must submit a SignedTransaction\nencoded as BCS. See SignedTransaction in types/src/transaction/mod.rs.\nMake sure to use the `application/x.aptos.signed_transaction+bcs` Content-Type.",
         "requestBody": {
@@ -9308,9 +9272,7 @@
     },
     "/transactions/by_hash/{txn_hash}": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Get transaction by hash",
         "description": "Look up a transaction by its hash. This is the same hash that is returned\nby the API when submitting a transaction (see PendingTransaction).\n\nWhen given a transaction hash, the server first looks for the transaction\nin storage (on-chain, committed). If no on-chain transaction is found, it\nlooks the transaction up by hash in the mempool (pending, not yet committed).\n\nTo create a transaction hash by yourself, do the following:\n1. Hash message bytes: \"RawTransaction\" bytes + BCS bytes of [Transaction](https://aptos-labs.github.io/aptos-core/aptos_types/transaction/enum.Transaction.html).\n2. Apply hash algorithm `SHA3-256` to the hash message bytes.\n3. Hex-encode the hash bytes with `0x` prefix.",
         "parameters": [
@@ -9888,9 +9850,7 @@
     },
     "/transactions/wait_by_hash/{txn_hash}": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Wait for transaction by hash",
         "description": "Same as /transactions/by_hash, but will wait for a pending transaction to be committed. To be used as a long\npoll optimization by clients, to reduce latency caused by polling. The \"long\" poll is generally a second or\nless but dictated by the server; the client must deal with the result as if the request was a normal\n/transactions/by_hash request, e.g., by retrying if the transaction is pending.",
         "parameters": [
@@ -10468,9 +10428,7 @@
     },
     "/transactions/by_version/{txn_version}": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Get transaction by version",
         "description": "Retrieves a transaction by a given version. If the version has been\npruned, a 410 will be returned.",
         "parameters": [
@@ -11048,9 +11006,7 @@
     },
     "/accounts/{address}/transactions": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Get account transactions",
         "description": "Retrieves on-chain committed transactions from an account. If the start\nversion is too far in the past, a 410 will be returned.\n\nIf no start version is given, it will start at version 0.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
@@ -11654,9 +11610,7 @@
     },
     "/transactions/batch": {
       "post": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Submit batch transactions",
         "description": "This allows you to submit multiple transactions.  The response has three outcomes:\n\n1. All transactions succeed, and it will return a 202\n2. Some transactions succeed, and it will return the failed transactions and a 206\n3. No transactions succeed, and it will also return the failed transactions and a 206\n\nTo submit a transaction as JSON, you must submit a SubmitTransactionRequest.\nTo build this request, do the following:\n\n1. Encode the transaction as BCS. If you are using a language that has\nnative BCS support, make sure to use that library. If not, you may take\nadvantage of /transactions/encode_submission. When using this\nendpoint, make sure you trust the node you're talking to, as it is\npossible they could manipulate your request.\n2. Sign the encoded transaction and use it to create a TransactionSignature.\n3. Submit the request. Make sure to use the \"application/json\" Content-Type.\n\nTo submit a transaction as BCS, you must submit a SignedTransaction\nencoded as BCS. See SignedTransaction in types/src/transaction/mod.rs.\nMake sure to use the `application/x.aptos.signed_transaction+bcs` Content-Type.",
         "requestBody": {
@@ -12418,9 +12372,7 @@
     },
     "/transactions/simulate": {
       "post": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Simulate transaction",
         "description": "The output of the transaction will have the exact transaction outputs and events that running\nan actual signed transaction would have.  However, it will not have the associated state\nhashes, as they are not updated in storage.  This can be used to estimate the maximum gas\nunits for a submitted transaction.\n\nTo use this, you must:\n- Create a SignedTransaction with a zero-padded signature.\n- Submit a SubmitTransactionRequest containing a UserTransactionRequest containing that signature.\n\nTo use this endpoint with BCS, you must submit a SignedTransaction\nencoded as BCS. See SignedTransaction in types/src/transaction/mod.rs.",
         "parameters": [
@@ -13118,9 +13070,7 @@
     },
     "/transactions/encode_submission": {
       "post": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Encode submission",
         "description": "This endpoint accepts an EncodeSubmissionRequest, which internally is a\nUserTransactionRequestInner (and optionally secondary signers) encoded\nas JSON, validates the request format, and then returns that request\nencoded in BCS. The client can then use this to create a transaction\nsignature to be used in a SubmitTransactionRequest, which it then\npasses to the /transactions POST endpoint.\n\nTo be clear, this endpoint makes it possible to submit transaction\nrequests to the API from languages that do not have library support for\nBCS. If you are using an SDK that has BCS support, such as the official\nRust, TypeScript, or Python SDKs, you do not need to use this endpoint.\n\nTo sign a message using the response from this endpoint:\n- Decode the hex encoded string in the response to bytes.\n- Sign the bytes to create the signature.\n- Use that as the signature field in something like Ed25519Signature, which you then use to build a TransactionSignature.",
         "requestBody": {
@@ -13543,9 +13493,7 @@
     },
     "/estimate_gas_price": {
       "get": {
-        "tags": [
-          "Transactions"
-        ],
+        "tags": ["Transactions"],
         "summary": "Estimate gas price",
         "description": "Gives an estimate of the gas unit price required to get a transaction on chain in a\nreasonable amount of time. The gas unit price is the amount that each transaction commits to\npay for each unit of gas consumed in executing the transaction. The estimate is based on\nrecent history: it gives the minimum gas that would have been required to get into recent\nblocks, for blocks that were full. (When blocks are not full, the estimate will match the\nminimum gas unit price.)\n\nThe estimation is given in three values: de-prioritized (low), regular, and prioritized\n(aggressive). Using a more aggressive value increases the likelihood that the transaction\nwill make it into the next block; more aggressive values are computed with a larger history\nand higher percentile statistics. More details are in AIP-34.",
         "responses": {
@@ -13958,9 +13906,7 @@
     },
     "/view": {
       "post": {
-        "tags": [
-          "View"
-        ],
+        "tags": ["View"],
         "summary": "Execute view function of a module",
         "description": "Execute the Move function with the given parameters and return its execution result.\n\nThe Aptos nodes prune account state history, via a configurable time window.\nIf the requested ledger version has been pruned, the server responds with a 410.",
         "parameters": [
@@ -14563,10 +14509,7 @@
     "schemas": {
       "AbstractionSignature": {
         "type": "object",
-        "required": [
-          "function_info",
-          "auth_data"
-        ],
+        "required": ["function_info", "auth_data"],
         "properties": {
           "function_info": {
             "type": "string"
@@ -14579,10 +14522,7 @@
       "AccountData": {
         "type": "object",
         "description": "Account data\n\nA simplified version of the onchain Account resource",
-        "required": [
-          "sequence_number",
-          "authentication_key"
-        ],
+        "required": ["sequence_number", "authentication_key"],
         "properties": {
           "sequence_number": {
             "$ref": "#/components/schemas/U64"
@@ -14631,15 +14571,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "abstraction_signature"
-                ],
+                "enum": ["abstraction_signature"],
                 "example": "abstraction_signature"
               }
             }
@@ -14653,15 +14589,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "ed25519_signature"
-                ],
+                "enum": ["ed25519_signature"],
                 "example": "ed25519_signature"
               }
             }
@@ -14675,15 +14607,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "multi_ed25519_signature"
-                ],
+                "enum": ["multi_ed25519_signature"],
                 "example": "multi_ed25519_signature"
               }
             }
@@ -14697,15 +14625,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "multi_key_signature"
-                ],
+                "enum": ["multi_key_signature"],
                 "example": "multi_key_signature"
               }
             }
@@ -14719,15 +14643,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "no_account_signature"
-                ],
+                "enum": ["no_account_signature"],
                 "example": "no_account_signature"
               }
             }
@@ -14741,15 +14661,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "single_key_signature"
-                ],
+                "enum": ["single_key_signature"],
                 "example": "single_key_signature"
               }
             }
@@ -14768,10 +14684,7 @@
       "AptosError": {
         "type": "object",
         "description": "This is the generic struct we use for all API errors, it contains a string\nmessage and an Aptos API specific error code.",
-        "required": [
-          "message",
-          "error_code"
-        ],
+        "required": ["message", "error_code"],
         "properties": {
           "message": {
             "type": "string",
@@ -14973,15 +14886,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "v0"
-                ],
+                "enum": ["v0"],
                 "example": "v0"
               }
             }
@@ -14995,15 +14904,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "v1"
-                ],
+                "enum": ["v1"],
                 "example": "v1"
               }
             }
@@ -15193,12 +15098,7 @@
       "DecodedTableData": {
         "type": "object",
         "description": "Decoded table data",
-        "required": [
-          "key",
-          "key_type",
-          "value",
-          "value_type"
-        ],
+        "required": ["key", "key_type", "value", "value_type"],
         "properties": {
           "key": {
             "description": "Key of table in JSON"
@@ -15219,11 +15119,7 @@
       "DeleteModule": {
         "type": "object",
         "description": "Delete a module",
-        "required": [
-          "address",
-          "state_key_hash",
-          "module"
-        ],
+        "required": ["address", "state_key_hash", "module"],
         "properties": {
           "address": {
             "$ref": "#/components/schemas/Address"
@@ -15240,11 +15136,7 @@
       "DeleteResource": {
         "type": "object",
         "description": "Delete a resource",
-        "required": [
-          "address",
-          "state_key_hash",
-          "resource"
-        ],
+        "required": ["address", "state_key_hash", "resource"],
         "properties": {
           "address": {
             "$ref": "#/components/schemas/Address"
@@ -15261,11 +15153,7 @@
       "DeleteTableItem": {
         "type": "object",
         "description": "Delete a table item",
-        "required": [
-          "state_key_hash",
-          "handle",
-          "key"
-        ],
+        "required": ["state_key_hash", "handle", "key"],
         "properties": {
           "state_key_hash": {
             "type": "string"
@@ -15284,10 +15172,7 @@
       "DeletedTableData": {
         "type": "object",
         "description": "Deleted table data",
-        "required": [
-          "key",
-          "key_type"
-        ],
+        "required": ["key", "key_type"],
         "properties": {
           "key": {
             "description": "Deleted key"
@@ -15303,10 +15188,7 @@
       },
       "DirectWriteSet": {
         "type": "object",
-        "required": [
-          "changes",
-          "events"
-        ],
+        "required": ["changes", "events"],
         "properties": {
           "changes": {
             "type": "array",
@@ -15324,9 +15206,7 @@
       },
       "Ed25519": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -15336,10 +15216,7 @@
       "Ed25519Signature": {
         "type": "object",
         "description": "A single Ed25519 signature",
-        "required": [
-          "public_key",
-          "signature"
-        ],
+        "required": ["public_key", "signature"],
         "properties": {
           "public_key": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -15396,11 +15273,7 @@
       "EntryFunctionPayload": {
         "type": "object",
         "description": "Payload which runs a single entry function",
-        "required": [
-          "function",
-          "type_arguments",
-          "arguments"
-        ],
+        "required": ["function", "type_arguments", "arguments"],
         "properties": {
           "function": {
             "$ref": "#/components/schemas/EntryFunctionId"
@@ -15422,12 +15295,7 @@
       "Event": {
         "type": "object",
         "description": "An event from a transaction",
-        "required": [
-          "guid",
-          "sequence_number",
-          "type",
-          "data"
-        ],
+        "required": ["guid", "sequence_number", "type", "data"],
         "properties": {
           "guid": {
             "$ref": "#/components/schemas/EventGuid"
@@ -15445,10 +15313,7 @@
       },
       "EventGuid": {
         "type": "object",
-        "required": [
-          "creation_number",
-          "account_address"
-        ],
+        "required": ["creation_number", "account_address"],
         "properties": {
           "creation_number": {
             "$ref": "#/components/schemas/U64"
@@ -15461,9 +15326,7 @@
       "ExportedAggregateSignature": {
         "type": "object",
         "description": "A more API-friendly representation of the on-chain `aptos_types::aggregate_signature::AggregateSignature`.",
-        "required": [
-          "signer_indices"
-        ],
+        "required": ["signer_indices"],
         "properties": {
           "signer_indices": {
             "type": "array",
@@ -15479,11 +15342,7 @@
       },
       "ExportedDKGTranscript": {
         "type": "object",
-        "required": [
-          "epoch",
-          "author",
-          "payload"
-        ],
+        "required": ["epoch", "author", "payload"],
         "properties": {
           "epoch": {
             "$ref": "#/components/schemas/U64"
@@ -15499,11 +15358,7 @@
       "ExportedProviderJWKs": {
         "type": "object",
         "description": "A more API-friendly representation of the on-chain `aptos_types::jwks::ProviderJWKs`.",
-        "required": [
-          "issuer",
-          "version",
-          "jwks"
-        ],
+        "required": ["issuer", "version", "jwks"],
         "properties": {
           "issuer": {
             "type": "string"
@@ -15523,10 +15378,7 @@
       "ExportedQuorumCertifiedUpdate": {
         "type": "object",
         "description": "A more API-friendly representation of the on-chain `aptos_types::jwks::QuorumCertifiedUpdate`.",
-        "required": [
-          "update",
-          "multi_sig"
-        ],
+        "required": ["update", "multi_sig"],
         "properties": {
           "update": {
             "$ref": "#/components/schemas/ExportedProviderJWKs"
@@ -15538,9 +15390,7 @@
       },
       "FederatedKeyless": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -15600,9 +15450,7 @@
       "GasEstimation": {
         "type": "object",
         "description": "Struct holding the outputs of the estimate gas API",
-        "required": [
-          "gas_estimate"
-        ],
+        "required": ["gas_estimate"],
         "properties": {
           "deprioritized_gas_estimate": {
             "type": "integer",
@@ -15640,15 +15488,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "write_set_payload"
-                ],
+                "enum": ["write_set_payload"],
                 "example": "write_set_payload"
               }
             }
@@ -15729,9 +15573,7 @@
       "HealthCheckSuccess": {
         "type": "object",
         "description": "Representation of a successful healthcheck",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "properties": {
           "message": {
             "type": "string"
@@ -15795,10 +15637,7 @@
       },
       "IndexedSignature": {
         "type": "object",
-        "required": [
-          "index",
-          "signature"
-        ],
+        "required": ["index", "signature"],
         "properties": {
           "index": {
             "type": "integer",
@@ -15890,9 +15729,7 @@
       },
       "Keyless": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -15955,9 +15792,7 @@
       "MoveFunctionGenericTypeParam": {
         "type": "object",
         "description": "Move function generic type param",
-        "required": [
-          "constraints"
-        ],
+        "required": ["constraints"],
         "properties": {
           "constraints": {
             "type": "array",
@@ -15971,22 +15806,12 @@
       "MoveFunctionVisibility": {
         "type": "string",
         "description": "Move function visibility",
-        "enum": [
-          "private",
-          "public",
-          "friend"
-        ]
+        "enum": ["private", "public", "friend"]
       },
       "MoveModule": {
         "type": "object",
         "description": "A Move module",
-        "required": [
-          "address",
-          "name",
-          "friends",
-          "exposed_functions",
-          "structs"
-        ],
+        "required": ["address", "name", "friends", "exposed_functions", "structs"],
         "properties": {
           "address": {
             "$ref": "#/components/schemas/Address"
@@ -16020,9 +15845,7 @@
       "MoveModuleBytecode": {
         "type": "object",
         "description": "Move module bytecode along with it's ABI",
-        "required": [
-          "bytecode"
-        ],
+        "required": ["bytecode"],
         "properties": {
           "bytecode": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -16040,10 +15863,7 @@
       "MoveResource": {
         "type": "object",
         "description": "A parsed Move resource",
-        "required": [
-          "type",
-          "data"
-        ],
+        "required": ["type", "data"],
         "properties": {
           "type": {
             "$ref": "#/components/schemas/MoveStructTag"
@@ -16056,9 +15876,7 @@
       "MoveScriptBytecode": {
         "type": "object",
         "description": "Move script bytecode",
-        "required": [
-          "bytecode"
-        ],
+        "required": ["bytecode"],
         "properties": {
           "bytecode": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -16071,14 +15889,7 @@
       "MoveStruct": {
         "type": "object",
         "description": "A move struct",
-        "required": [
-          "name",
-          "is_native",
-          "is_event",
-          "abilities",
-          "generic_type_params",
-          "fields"
-        ],
+        "required": ["name", "is_native", "is_event", "abilities", "generic_type_params", "fields"],
         "properties": {
           "name": {
             "$ref": "#/components/schemas/IdentifierWrapper"
@@ -16117,10 +15928,7 @@
       "MoveStructField": {
         "type": "object",
         "description": "Move struct field",
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "properties": {
           "name": {
             "$ref": "#/components/schemas/IdentifierWrapper"
@@ -16133,9 +15941,7 @@
       "MoveStructGenericTypeParam": {
         "type": "object",
         "description": "Move generic type param",
-        "required": [
-          "constraints"
-        ],
+        "required": ["constraints"],
         "properties": {
           "constraints": {
             "type": "array",
@@ -16220,11 +16026,7 @@
       "MultiAgentSignature": {
         "type": "object",
         "description": "Multi agent signature for multi agent transactions\n\nThis allows you to have transactions across multiple accounts",
-        "required": [
-          "sender",
-          "secondary_signer_addresses",
-          "secondary_signers"
-        ],
+        "required": ["sender", "secondary_signer_addresses", "secondary_signers"],
         "properties": {
           "sender": {
             "$ref": "#/components/schemas/AccountSignature"
@@ -16248,12 +16050,7 @@
       "MultiEd25519Signature": {
         "type": "object",
         "description": "A Ed25519 multi-sig signature\n\nThis allows k-of-n signing for a transaction",
-        "required": [
-          "public_keys",
-          "signatures",
-          "threshold",
-          "bitmap"
-        ],
+        "required": ["public_keys", "signatures", "threshold", "bitmap"],
         "properties": {
           "public_keys": {
             "type": "array",
@@ -16282,11 +16079,7 @@
       "MultiKeySignature": {
         "type": "object",
         "description": "A multi key signature",
-        "required": [
-          "public_keys",
-          "signatures",
-          "signatures_required"
-        ],
+        "required": ["public_keys", "signatures", "signatures_required"],
         "properties": {
           "public_keys": {
             "type": "array",
@@ -16309,9 +16102,7 @@
       "MultisigPayload": {
         "type": "object",
         "description": "A multisig transaction that allows an owner of a multisig account to execute a pre-approved\ntransaction as the multisig account.",
-        "required": [
-          "multisig_address"
-        ],
+        "required": ["multisig_address"],
         "properties": {
           "multisig_address": {
             "$ref": "#/components/schemas/Address"
@@ -16339,15 +16130,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "entry_function_payload"
-                ],
+                "enum": ["entry_function_payload"],
                 "example": "entry_function_payload"
               }
             }
@@ -16434,15 +16221,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "ed25519"
-                ],
+                "enum": ["ed25519"],
                 "example": "ed25519"
               }
             }
@@ -16456,15 +16239,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "federated_keyless"
-                ],
+                "enum": ["federated_keyless"],
                 "example": "federated_keyless"
               }
             }
@@ -16478,15 +16257,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "keyless"
-                ],
+                "enum": ["keyless"],
                 "example": "keyless"
               }
             }
@@ -16500,15 +16275,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "secp256k1_ecdsa"
-                ],
+                "enum": ["secp256k1_ecdsa"],
                 "example": "secp256k1_ecdsa"
               }
             }
@@ -16522,15 +16293,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "secp256r1_ecdsa"
-                ],
+                "enum": ["secp256r1_ecdsa"],
                 "example": "secp256r1_ecdsa"
               }
             }
@@ -16543,13 +16310,7 @@
       "RSA_JWK": {
         "type": "object",
         "description": "Move type `0x1::jwks::RSA_JWK` in rust.\nSee its doc in Move for more details.",
-        "required": [
-          "kid",
-          "kty",
-          "alg",
-          "e",
-          "n"
-        ],
+        "required": ["kid", "kty", "alg", "e", "n"],
         "properties": {
           "kid": {
             "type": "string"
@@ -16571,9 +16332,7 @@
       "RawTableItemRequest": {
         "type": "object",
         "description": "Table Item request for the GetTableItemRaw API",
-        "required": [
-          "key"
-        ],
+        "required": ["key"],
         "properties": {
           "key": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -16582,19 +16341,12 @@
       },
       "RoleType": {
         "type": "string",
-        "enum": [
-          "validator",
-          "full_node"
-        ]
+        "enum": ["validator", "full_node"]
       },
       "ScriptPayload": {
         "type": "object",
         "description": "Payload which runs a script that can run multiple functions",
-        "required": [
-          "code",
-          "type_arguments",
-          "arguments"
-        ],
+        "required": ["code", "type_arguments", "arguments"],
         "properties": {
           "code": {
             "$ref": "#/components/schemas/MoveScriptBytecode"
@@ -16615,10 +16367,7 @@
       },
       "ScriptWriteSet": {
         "type": "object",
-        "required": [
-          "execute_as",
-          "script"
-        ],
+        "required": ["execute_as", "script"],
         "properties": {
           "execute_as": {
             "$ref": "#/components/schemas/Address"
@@ -16630,9 +16379,7 @@
       },
       "Secp256k1Ecdsa": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -16641,9 +16388,7 @@
       },
       "Secp256r1Ecdsa": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -16680,15 +16425,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "ed25519"
-                ],
+                "enum": ["ed25519"],
                 "example": "ed25519"
               }
             }
@@ -16702,15 +16443,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "keyless"
-                ],
+                "enum": ["keyless"],
                 "example": "keyless"
               }
             }
@@ -16724,15 +16461,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "secp256k1_ecdsa"
-                ],
+                "enum": ["secp256k1_ecdsa"],
                 "example": "secp256k1_ecdsa"
               }
             }
@@ -16746,15 +16479,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "web_authn"
-                ],
+                "enum": ["web_authn"],
                 "example": "web_authn"
               }
             }
@@ -16767,10 +16496,7 @@
       "SingleKeySignature": {
         "type": "object",
         "description": "A single key signature",
-        "required": [
-          "public_key",
-          "signature"
-        ],
+        "required": ["public_key", "signature"],
         "properties": {
           "public_key": {
             "$ref": "#/components/schemas/PublicKey"
@@ -16881,11 +16607,7 @@
       "TableItemRequest": {
         "type": "object",
         "description": "Table Item request for the GetTableItem API",
-        "required": [
-          "key_type",
-          "value_type",
-          "key"
-        ],
+        "required": ["key_type", "value_type", "key"],
         "properties": {
           "key_type": {
             "$ref": "#/components/schemas/MoveType"
@@ -16968,15 +16690,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "module_bundle_payload"
-                ],
+                "enum": ["module_bundle_payload"],
                 "example": "module_bundle_payload"
               }
             }
@@ -16990,15 +16708,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "entry_function_payload"
-                ],
+                "enum": ["entry_function_payload"],
                 "example": "entry_function_payload"
               }
             }
@@ -17012,15 +16726,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "multisig_payload"
-                ],
+                "enum": ["multisig_payload"],
                 "example": "multisig_payload"
               }
             }
@@ -17034,15 +16744,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "script_payload"
-                ],
+                "enum": ["script_payload"],
                 "example": "script_payload"
               }
             }
@@ -17091,15 +16797,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "single_sender"
-                ],
+                "enum": ["single_sender"],
                 "example": "single_sender"
               }
             }
@@ -17113,15 +16815,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "ed25519_signature"
-                ],
+                "enum": ["ed25519_signature"],
                 "example": "ed25519_signature"
               }
             }
@@ -17135,15 +16833,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "fee_payer_signature"
-                ],
+                "enum": ["fee_payer_signature"],
                 "example": "fee_payer_signature"
               }
             }
@@ -17157,15 +16851,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "multi_agent_signature"
-                ],
+                "enum": ["multi_agent_signature"],
                 "example": "multi_agent_signature"
               }
             }
@@ -17179,15 +16869,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "multi_ed25519_signature"
-                ],
+                "enum": ["multi_ed25519_signature"],
                 "example": "multi_ed25519_signature"
               }
             }
@@ -17201,15 +16887,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "no_account_signature"
-                ],
+                "enum": ["no_account_signature"],
                 "example": "no_account_signature"
               }
             }
@@ -17223,15 +16905,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "block_epilogue_transaction"
-                ],
+                "enum": ["block_epilogue_transaction"],
                 "example": "block_epilogue_transaction"
               }
             }
@@ -17245,15 +16923,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "block_metadata_transaction"
-                ],
+                "enum": ["block_metadata_transaction"],
                 "example": "block_metadata_transaction"
               }
             }
@@ -17267,15 +16941,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "genesis_transaction"
-                ],
+                "enum": ["genesis_transaction"],
                 "example": "genesis_transaction"
               }
             }
@@ -17289,15 +16959,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "pending_transaction"
-                ],
+                "enum": ["pending_transaction"],
                 "example": "pending_transaction"
               }
             }
@@ -17311,15 +16977,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "state_checkpoint_transaction"
-                ],
+                "enum": ["state_checkpoint_transaction"],
                 "example": "state_checkpoint_transaction"
               }
             }
@@ -17333,15 +16995,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "user_transaction"
-                ],
+                "enum": ["user_transaction"],
                 "example": "user_transaction"
               }
             }
@@ -17355,15 +17013,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "validator_transaction"
-                ],
+                "enum": ["validator_transaction"],
                 "example": "validator_transaction"
               }
             }
@@ -17376,10 +17030,7 @@
       "TransactionsBatchSingleSubmissionFailure": {
         "type": "object",
         "description": "Information telling which batch submission transactions failed",
-        "required": [
-          "error",
-          "transaction_index"
-        ],
+        "required": ["error", "transaction_index"],
         "properties": {
           "error": {
             "$ref": "#/components/schemas/AptosError"
@@ -17394,9 +17045,7 @@
       "TransactionsBatchSubmissionResult": {
         "type": "object",
         "description": "Batch transaction submission result\n\nTells which transactions failed",
-        "required": [
-          "transaction_failures"
-        ],
+        "required": ["transaction_failures"],
         "properties": {
           "transaction_failures": {
             "type": "array",
@@ -17428,10 +17077,7 @@
       "UnsupportedJWK": {
         "type": "object",
         "description": "Move type `0x1::jwks::UnsupportedJWK` in rust.\nSee its doc in Move for more details.",
-        "required": [
-          "id",
-          "payload"
-        ],
+        "required": ["id", "payload"],
         "properties": {
           "id": {
             "type": "array",
@@ -17563,15 +17209,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "validator_transaction_type"
-            ],
+            "required": ["validator_transaction_type"],
             "properties": {
               "validator_transaction_type": {
                 "type": "string",
-                "enum": [
-                  "dkg_result"
-                ],
+                "enum": ["dkg_result"],
                 "example": "dkg_result"
               }
             }
@@ -17585,15 +17227,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "validator_transaction_type"
-            ],
+            "required": ["validator_transaction_type"],
             "properties": {
               "validator_transaction_type": {
                 "type": "string",
-                "enum": [
-                  "observed_jwk_update"
-                ],
+                "enum": ["observed_jwk_update"],
                 "example": "observed_jwk_update"
               }
             }
@@ -17606,13 +17244,7 @@
       "VersionedEvent": {
         "type": "object",
         "description": "An event from a transaction with a version",
-        "required": [
-          "version",
-          "guid",
-          "sequence_number",
-          "type",
-          "data"
-        ],
+        "required": ["version", "guid", "sequence_number", "type", "data"],
         "properties": {
           "version": {
             "$ref": "#/components/schemas/U64"
@@ -17634,11 +17266,7 @@
       "ViewRequest": {
         "type": "object",
         "description": "View request for the Move View Function API",
-        "required": [
-          "function",
-          "type_arguments",
-          "arguments"
-        ],
+        "required": ["function", "type_arguments", "arguments"],
         "properties": {
           "function": {
             "$ref": "#/components/schemas/EntryFunctionId"
@@ -17659,9 +17287,7 @@
       },
       "WebAuthn": {
         "type": "object",
-        "required": [
-          "value"
-        ],
+        "required": ["value"],
         "properties": {
           "value": {
             "$ref": "#/components/schemas/HexEncodedBytes"
@@ -17671,11 +17297,7 @@
       "WriteModule": {
         "type": "object",
         "description": "Write a new module or update an existing one",
-        "required": [
-          "address",
-          "state_key_hash",
-          "data"
-        ],
+        "required": ["address", "state_key_hash", "data"],
         "properties": {
           "address": {
             "$ref": "#/components/schemas/Address"
@@ -17692,11 +17314,7 @@
       "WriteResource": {
         "type": "object",
         "description": "Write a resource or update an existing one",
-        "required": [
-          "address",
-          "state_key_hash",
-          "data"
-        ],
+        "required": ["address", "state_key_hash", "data"],
         "properties": {
           "address": {
             "$ref": "#/components/schemas/Address"
@@ -17768,15 +17386,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "delete_module"
-                ],
+                "enum": ["delete_module"],
                 "example": "delete_module"
               }
             }
@@ -17790,15 +17404,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "delete_resource"
-                ],
+                "enum": ["delete_resource"],
                 "example": "delete_resource"
               }
             }
@@ -17812,15 +17422,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "delete_table_item"
-                ],
+                "enum": ["delete_table_item"],
                 "example": "delete_table_item"
               }
             }
@@ -17834,15 +17440,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "write_module"
-                ],
+                "enum": ["write_module"],
                 "example": "write_module"
               }
             }
@@ -17856,15 +17458,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "write_resource"
-                ],
+                "enum": ["write_resource"],
                 "example": "write_resource"
               }
             }
@@ -17878,15 +17476,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "write_table_item"
-                ],
+                "enum": ["write_table_item"],
                 "example": "write_table_item"
               }
             }
@@ -17899,9 +17493,7 @@
       "WriteSetPayload": {
         "type": "object",
         "description": "A writeset payload, used only for genesis",
-        "required": [
-          "write_set"
-        ],
+        "required": ["write_set"],
         "properties": {
           "write_set": {
             "$ref": "#/components/schemas/WriteSet"
@@ -17912,15 +17504,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "direct_write_set"
-                ],
+                "enum": ["direct_write_set"],
                 "example": "direct_write_set"
               }
             }
@@ -17934,15 +17522,11 @@
         "allOf": [
           {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "script_write_set"
-                ],
+                "enum": ["script_write_set"],
                 "example": "script_write_set"
               }
             }
@@ -17955,12 +17539,7 @@
       "WriteTableItem": {
         "type": "object",
         "description": "Change set to write a table item",
-        "required": [
-          "state_key_hash",
-          "handle",
-          "key",
-          "value"
-        ],
+        "required": ["state_key_hash", "handle", "key", "value"],
         "properties": {
           "state_key_hash": {
             "type": "string"

--- a/src/components/OpenAPI/operation/OperationExamples/OperationScalarModal.astro
+++ b/src/components/OpenAPI/operation/OperationExamples/OperationScalarModal.astro
@@ -56,7 +56,7 @@ import "@scalar/api-client/style.css";
       const { open } = await createApiClientModal({
         el: scalarContainer,
         configuration: {
-          url: "/aptos-spec.json",
+          url: "/libra2-spec.json",
           servers,
           showSidebar: false,
           hideClientButton: true,

--- a/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
+++ b/src/content/docs/build/apis/aptos-labs-developer-portal.mdx
@@ -1,7 +1,0 @@
----
-title: "Aptos Labs Aptos Build"
----
-
-[Aptos Build](https://build.aptoslabs.com) is your gateway to access Aptos Labs provided APIs in a quick and easy fashion to power your dapp. Beyond API access it offers gas station and no code indexing services.
-
-Learn more about Aptos Build at the dedicated [Aptos Build docs site](https://build.aptoslabs.com/docs).

--- a/src/content/docs/build/apis/libra2-core-developer-portal.mdx
+++ b/src/content/docs/build/apis/libra2-core-developer-portal.mdx
@@ -1,0 +1,7 @@
+---
+title: "Libra2 Labs Libra2 Build"
+---
+
+[Libra2 Build](https://build.aptoslabs.com) is your gateway to access Libra2 Labs provided APIs in a quick and easy fashion to power your dapp. Beyond API access it offers gas station and no code indexing services.
+
+Learn more about Libra2 Build at the dedicated [Libra2 Build docs site](https://build.aptoslabs.com/docs).

--- a/src/content/docs/zh/build/apis.mdx
+++ b/src/content/docs/zh/build/apis.mdx
@@ -56,4 +56,4 @@ For testnet, you can mint APT at the [mint page](/zh/network/faucet).
 目前有两组 Aptos Labs API 部署:
 
 1. [具有匿名访问和基于 IP 的速率限制的 API](/zh/network/nodes/networks)
-2. [\[Beta\] 通过 Aptos Labs Developer Portal 进行身份验证和基于开发者账户的速率限制的 API](/zh/build/apis/aptos-labs-developer-portal)
+2. [\[Beta\] 通过 Libra2 Labs Developer Portal 进行身份验证和基于开发者账户的速率限制的 API](/zh/build/apis/libra2-core-developer-portal)


### PR DESCRIPTION
## Summary
- rename developer portal doc to match new Libra2 slug and rebrand sidebar group
- update OpenAPI spec filename and references to `libra2-spec.json`
- refresh Chinese API doc link to new developer portal page

## Testing
- `pnpm lint` *(fails: @typescript-eslint errors in src/utils/groupPagesByLang.ts)*
- `pnpm check`
- `pnpm lint:prettier`


------
https://chatgpt.com/codex/tasks/task_e_689973bb271c83328a2393ab272d5cd8